### PR TITLE
Prevent symlink files from consumer-postgres from being inadvertently included in gem file

### DIFF
--- a/consumer.gemspec
+++ b/consumer.gemspec
@@ -11,9 +11,16 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
 
   s.require_paths = ['lib']
-  s.files = Dir.glob('{lib}/**/*')
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.4.0'
+
+  files = Dir.glob('{lib}/**/*')
+
+  files.reject! do |file|
+    file.match?(/postgres/)
+  end
+
+  s.files = files
 
   s.bindir = 'bin'
 

--- a/consumer.gemspec
+++ b/consumer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   files = Dir.glob('{lib}/**/*')
 
   files.reject! do |file|
-    file.include?('lib/consumer/postgres') || file.include?('lib/consumer/_postgres')
+    File.symlink?(file)
   end
 
   s.files = files

--- a/consumer.gemspec
+++ b/consumer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   files = Dir.glob('{lib}/**/*')
 
   files.reject! do |file|
-    file.match?(/postgres/)
+    file.include?('lib/consumer/postgres') || file.include?('lib/consumer/_postgres')
   end
 
   s.files = files


### PR DESCRIPTION
For context: this project has historically included `lib/consumer/postgres.rb` and `lib/consumer/postgres` in its `.gitignore` file. This is because, when both the Consumer and Consumer::Postgres libraries are symlinked (i.e. with `./symlink-lib.sh`), the Consumer::Postgres symlinks get placed inside this project's `lib/consumer` directory, and we need to prevent those symlinks from ever being inadvertently added to the project. This is simply how things _have to be_ when symlinking multiple projects that share a common namespace (the way that Consumer and Consumer::Postgres share Consumer as a common namespace).

This change addresses _another_ issue that stems from having Consumer::Postgres symlinks placed in `lib/consumer` during development: when packaging the gem file, the `lib/consumer/postgres.rb` and `lib/consumer/postgres` symlinks are getting inadvertently added to the gem package. To counteract this, I changed the gemspec to exclude those symlinks from the gem. The specific symlinks excluded are the same ones that are in `.gitignore`.

I'm also hoping we can settle this matter once and for all, so that all the libraries like `Consumer` that can have symlinks from "inner" libraries like `Consumer::Postgres` get fixed. However we agree to solve the problem here, I'll introduce across the board.