### PR TITLE
Poll interval default can be set via an environment variable

### DIFF
--- a/lib/consumer/consumer.rb
+++ b/lib/consumer/consumer.rb
@@ -87,9 +87,7 @@ module Consumer
 
     print_startup_info if respond_to?(:print_startup_info)
 
-    if position_store.respond_to?(:stream_name)
-      STDOUT.puts "      Position Stream: #{position_store.stream_name}"
-    end
+    STDOUT.puts "      Position Location: #{position_store.location || '(none)'}"
 
     STDOUT.puts
 

--- a/lib/consumer/consumer.rb
+++ b/lib/consumer/consumer.rb
@@ -87,7 +87,9 @@ module Consumer
 
     print_startup_info if respond_to?(:print_startup_info)
 
-    STDOUT.puts "      Position Stream: #{position_store.stream_name}"
+    if position_store.respond_to?(:stream_name)
+      STDOUT.puts "      Position Stream: #{position_store.stream_name}"
+    end
 
     STDOUT.puts
 

--- a/lib/consumer/controls/get/incrementing.rb
+++ b/lib/consumer/controls/get/incrementing.rb
@@ -22,6 +22,10 @@ module Consumer
           instance
         end
 
+        def stream_name
+          Category.example
+        end
+
         def batch_size
           Defaults.batch_size
         end

--- a/lib/consumer/controls/position_store.rb
+++ b/lib/consumer/controls/position_store.rb
@@ -1,24 +1,35 @@
 module Consumer
   module Controls
     module PositionStore
-      def self.example
-        Example.build
+      def self.example(&block)
+        if block.nil?
+          cls = Example
+        else
+          cls = example_class(&block)
+        end
+
+        cls.build
       end
 
-      class Example
-        include ::Consumer::PositionStore
+      def self.example_class(&block)
+        Class.new do
+          include ::Consumer::PositionStore
 
+          def self.build
+            instance = new
+            instance.configure
+            instance
+          end
+
+          def configure
+          end
+
+          class_exec(&block) unless block.nil?
+        end
+      end
+
+      Example = example_class do
         attr_accessor :telemetry_sink
-
-        def stream_name
-          'somePositionStream'
-        end
-
-        def self.build
-          instance = new
-          instance.configure
-          instance
-        end
 
         def configure
           self.telemetry_sink = ::Consumer::PositionStore::Telemetry::Sink.new
@@ -31,6 +42,12 @@ module Consumer
         end
 
         def put(_)
+        end
+      end
+
+      module Location
+        def self.example
+          'somePositionStream'
         end
       end
     end

--- a/lib/consumer/position_store.rb
+++ b/lib/consumer/position_store.rb
@@ -3,6 +3,7 @@ module Consumer
     def self.included(cls)
       cls.class_exec do
         include Dependency
+        include Virtual
         include Log::Dependency
 
         extend Build
@@ -13,6 +14,8 @@ module Consumer
         prepend Put
 
         dependency :telemetry, ::Telemetry
+
+        virtual :location
       end
     end
 

--- a/lib/consumer/subscription.rb
+++ b/lib/consumer/subscription.rb
@@ -46,20 +46,20 @@ module Consumer
     end
 
     handle :resupply do
-      logger.trace { "Resupplying (Category: #{get.category}, Position: #{position})" }
+      logger.trace { "Resupplying (Stream: #{get.stream_name}, Position: #{position})" }
 
       batch = poll.() do
         get.(position)
       end
 
       if batch.nil? || batch.empty?
-        logger.debug { "Did not resupply; no events available (Category: #{get.category}, Position: #{position})" }
+        logger.debug { "Did not resupply; no events available (Stream: #{get.stream_name}, Position: #{position})" }
 
         :resupply
       else
         self.next_batch = batch
 
-        logger.debug { "Resupplied (Category: #{get.category}, Position: #{position}, Batch Size: #{batch.count})" }
+        logger.debug { "Resupplied (Stream: #{get.stream_name}, Position: #{position}, Batch Size: #{batch.count})" }
       end
     end
 

--- a/lib/consumer/subscription/defaults.rb
+++ b/lib/consumer/subscription/defaults.rb
@@ -2,6 +2,9 @@ module Consumer
   class Subscription
     module Defaults
       def self.poll_interval_milliseconds
+        env_interval = ENV['POLL_INTERVAL_MILLISECONDS']
+        return env_interval.to_i if !env_interval.nil?
+
         100
       end
 

--- a/test/automated/position_store/location.rb
+++ b/test/automated/position_store/location.rb
@@ -1,0 +1,27 @@
+require_relative '../automated_init'
+
+context "Position Store" do
+  context "Location" do
+    context "Implemented" do
+      location = Controls::PositionStore::Location.example
+
+      position_store = Controls::PositionStore.example do
+        attr_accessor :location
+      end
+
+      position_store.location = location
+
+      test do
+        assert(position_store.location == location)
+      end
+    end
+
+    context "Not Implemented" do
+      position_store = Controls::PositionStore.example
+
+      test do
+        assert(position_store.location.nil?)
+      end
+    end
+  end
+end

--- a/test/interactive/interactive_init.rb
+++ b/test/interactive/interactive_init.rb
@@ -1,3 +1,4 @@
+ENV['LOG_TAGS'] ||= '_untagged,consumer'
 ENV['LOG_LEVEL'] ||= 'trace'
 
 require_relative '../test_init'


### PR DESCRIPTION
Before this pull request, a consumer's polling interval can only be set when consumers are started, via the `poll_interval_milliseconds` keyword argument given to `#start`:

```ruby
SomeConsumer.start('someCategory', poll_interval_milliseconds: 10)
```

If that keyword argument is omitted, a default value of 100 milliseconds is used. This PR allows that value to be varied via `ENV['POLL_INTERVAL_MILLISECONDS']`. I debated back and forth on the name of the ENV variable, between `POLL_INTERVAL_MILLISECONDS` and `CONSUMER_POLL_INTERVAL_MILLISECONDS`, and see arguments for both. Currently, I have it as `POLL_INTERVAL_MILLISECONDS` but can of course easily change it to some better tradeoff between precision and succinctness.

Also, I noticed some of the interactive tests started failing as a result of the recent additions of startup info. The log text printed out when consumers start includes the position store's stream name. Not all position stores actually implement `#stream_name` -- specifically, the substitute and one of the control position stores both don't implement it. A `#stream_name` method does not make sense as part of a position store's protocol; it's perfectly valid for a position store to read and write position offsets to a local file, for example, and in that case there's no stream it's writing to. So, I added a check to ensure the position store responds to `#stream_name` before calling it. I don't love the `#respond_to?` check, but I don't see a way of fixing this that doesn't involve introducing more design elaboration to what is essentially diagnostic output.