### PR TITLE
Starting position is only retrieved once

### DIFF
--- a/lib/consumer/consumer.rb
+++ b/lib/consumer/consumer.rb
@@ -24,7 +24,11 @@ module Consumer
       end
 
       def starting_position
-        @starting_position ||= position_store.get
+        if not defined?(@starting_position)
+          @starting_position = position_store.get
+        end
+
+        @starting_position
       end
       attr_writer :starting_position
 


### PR DESCRIPTION
This addresses a problem with sharing the consumer's `get` across threads, which caused multiple threads to attempt to use `get` simultaneously. With consumer-postgres, this causes a malfunction.